### PR TITLE
fix TravisCI error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--index-url https://pypi.ccnmtl.columbia.edu/
 Django==1.7.10
 httplib2==0.8
 restclient==0.11.0


### PR DESCRIPTION
Travis tries to pip install requirements.txt directly, so it needs the
index-url specified.