### PR TITLE
Django 1.9 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,18 +27,6 @@
         }
       }
     },
-    "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
-      }
-    },
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
@@ -551,33 +539,33 @@
       }
     },
     "eslint": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.5.0.tgz",
-      "integrity": "sha1-u3XTuL3pf7XhPvzVOXRGd/6wGcM=",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.13.1.tgz",
+      "integrity": "sha512-UCJVV50RtLHYzBp1DZ8CMPtRSg4iVZvjgO9IJHIKyWU/AnJVjtdRikoUPLB29n5pzMB7TnsLQWf0V6VUJfoPfw==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
+        "ajv": "5.5.1",
         "babel-code-frame": "6.26.0",
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.8",
-        "doctrine": "2.0.0",
+        "debug": "3.1.0",
+        "doctrine": "2.0.2",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.0",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.1.0",
         "ignore": "3.3.3",
         "imurmurhash": "0.1.4",
         "inquirer": "3.2.2",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.9.1",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -585,7 +573,7 @@
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
+        "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
@@ -593,6 +581,66 @@
         "strip-json-comments": "2.0.1",
         "table": "4.0.1",
         "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+          "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2"
+          }
+        },
+        "espree": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+          "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.2.1",
+            "acorn-jsx": "3.0.1"
+          }
+        },
+        "globals": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+          "dev": true
+        }
       }
     },
     "eslint-config-scanjs": {
@@ -601,7 +649,7 @@
       "integrity": "sha1-YsqLQH6gksO01DATuttuep4tqsM=",
       "dev": true,
       "requires": {
-        "eslint": "4.5.0",
+        "eslint": "4.13.1",
         "eslint-plugin-no-unsanitized": "2.0.1",
         "eslint-plugin-no-wildcard-postmessage": "0.1.3",
         "eslint-plugin-scanjs-rules": "0.2.1"
@@ -1406,7 +1454,7 @@
       "dev": true,
       "requires": {
         "babel-eslint": "7.2.3",
-        "eslint": "4.5.0"
+        "eslint": "4.13.1"
       }
     },
     "eslint-plugin-security": {
@@ -1512,6 +1560,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -1833,6 +1887,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
@@ -2315,12 +2375,6 @@
       "requires": {
         "pinkie": "2.0.4"
       }
-    },
-    "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
-      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/pedialabsnew/exercises/models.py
+++ b/pedialabsnew/exercises/models.py
@@ -1,9 +1,9 @@
+from django import forms
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.fields import GenericRelation
+from django.core.urlresolvers import reverse
 from django.db import models
 from pagetree.models import PageBlock
-from django.contrib.auth.models import User
-from django.contrib.contenttypes import generic
-from django import forms
-from django.core.urlresolvers import reverse
 from pagetree.reports import ReportableInterface, ReportColumnInterface
 
 
@@ -34,7 +34,7 @@ class Lab(models.Model):
                  ("Refer for further tests", "Refer for further tests"),
                  ("Reassure and send home", "Reassure and send home"),
                  ])
-    pageblocks = generic.GenericRelation(PageBlock)
+    pageblocks = GenericRelation(PageBlock)
 
     template_file = "exercises/labblock.html"
     display_name = "Lab Exercise"

--- a/pedialabsnew/rstplot/models.py
+++ b/pedialabsnew/rstplot/models.py
@@ -1,12 +1,12 @@
 from django import forms
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from pagetree.models import PageBlock
 
 
 class RstPlotBlock(models.Model):
     display_name = "Rapid Strep Test Plot"
-    pageblocks = generic.GenericRelation(PageBlock)
+    pageblocks = GenericRelation(PageBlock)
     template_file = "rstplot/rstplot.html"
     js_template_file = "rstplot/block_js.html"
     css_template_file = "rstplot/block_css.html"

--- a/pedialabsnew/settings_shared.py
+++ b/pedialabsnew/settings_shared.py
@@ -21,7 +21,6 @@ TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
 INSTALLED_APPS += [  # noqa
     'bootstrap3',
     'sorl.thumbnail',
-    'typogrify',
     'bootstrapform',
     'django_extensions',
     'registration',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.18
+Django==1.9.13 # pyup: <1.10
 lxml==3.8.0
 feedparser==5.2.1
 Markdown==2.6.8
@@ -59,7 +59,6 @@ rcssmin==1.0.6
 django-bootstrap3==8.2.3
 djangowind==1.0.0
 requirements/src/sorl-3.1.tar.gz
-typogrify==2.0.7
 django-indexer==0.3.0
 django-templatetag-sugar==1.0
 django-paging==0.2.5
@@ -76,7 +75,7 @@ django-extensions==1.7.9
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-impersonate==1.1
-requirements/src/django-registration-1.1.tar.gz
+django-registration-redux==1.9
 django-treebeard==4.1.1
 django-pagetree==1.3.2
 django-pageblocks==1.1.0


### PR DESCRIPTION
The database migration will likely fail due to a switch from registration to registration-redux. The initial registration 0001 needs to be faked. I can usher the change through once the PR is merged.