### PR TITLE
Pin Markdown to <3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==1.11.17  # pyup: <2.0
 lxml==4.2.5
 feedparser==5.2.1
-Markdown==3.0.1
+Markdown==2.6.11  # pyup: <3.0
 simplejson==3.16.0
 smartypants==2.0.1
 uuid==1.30


### PR DESCRIPTION
Changes with Markdown's API are causing 500 errors:
* https://pedialabs.ccnmtl.columbia.edu/pages/public/overview/
* https://pedialabs.ccnmtl.columbia.edu/pages/labs/survey/

> TypeError at /pages/public/overview/
> markdown() takes exactly 1 argument (4 given)

https://python-markdown.github.io/change_log/release-3.0/