### PR TITLE
travis: remove python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "3.4"
   - "3.6"
 script:
   - make eslint


### PR DESCRIPTION
This app is now migrated to ubuntu 18